### PR TITLE
fix: Improve the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,38 @@
-# github-agent
+<h1 align="center">
+  <br>
+  🤖 github-agent
+  <br>
+</h1>
 
-> An AI that ships PRs — **and reviews its own work before opening them.**
+<h3 align="center">An AI that ships pull requests — and reviews its own work before opening them.</h3>
 
-`github-agent` is an autonomous engineering pipeline built on Claude Opus. Give it a GitHub issue URL; it clones the repo, edits files, runs tests, audits its own diff with a second Claude instance, and opens a pull request — all in one command.
+<p align="center">
+  <a href="#-quick-start">Quick Start</a> •
+  <a href="#-what-makes-this-different">Why github-agent</a> •
+  <a href="#️-architecture">Architecture</a> •
+  <a href="#-safety-guardrails">Safety</a> •
+  <a href="#-roadmap">Roadmap</a>
+</p>
+
+<p align="center">
+  <img src="https://img.shields.io/badge/model-Claude%20Sonnet-blueviolet?style=flat-square&logo=anthropic" alt="Claude Sonnet">
+  <img src="https://img.shields.io/badge/license-MIT-green?style=flat-square" alt="MIT License">
+  <img src="https://img.shields.io/badge/node-%3E%3D18-brightgreen?style=flat-square&logo=node.js" alt="Node 18+">
+</p>
+
+---
+
+`github-agent` is an **autonomous engineering pipeline** built on Claude. Give it a GitHub issue URL; it clones the repo, edits the code, runs the tests, has a **second AI instance review the diff**, and opens a pull request — all in one command.
 
 ```bash
+node src/pipeline.js issue https://github.com/your/repo/issues/42
+```
+
+---
+
+## ✨ See it in action
+
+```
 $ node src/pipeline.js issue https://github.com/your/repo/issues/42
 
    ╔════════════════════════════════════════════╗
@@ -28,7 +56,7 @@ $ node src/pipeline.js issue https://github.com/your/repo/issues/42
   🔧 apply_patch(src/auth/login.js, ...)
   🔧 run_tests(npm test)
      → ok
-  🔧 finish({"pr_summary":"Lowercase email at..."})
+  🔧 finish({"pr_summary":"Lowercase email before lookup..."})
   ✓ Agent finished after 4 turn(s)
 
 ▸ Self-review — auditing the diff
@@ -45,141 +73,213 @@ Token usage (engineering + revision)
   ✓ PR opened: https://github.com/your/repo/pull/431
 ```
 
-## What makes this different
+---
 
-Most AI coding tools generate code and hand it to a human. `github-agent` ships it.
+## 🏆 What makes this different
 
-| | Copilot / Cursor | Devin / SWE-agent | **github-agent** |
-|---|---|---|---|
+Most AI coding tools **generate code and hand it to a human.** `github-agent` **ships it** — and audits itself first.
+
+|  | Copilot / Cursor | Devin / SWE-agent | **github-agent** |
+|---|:---:|:---:|:---:|
 | Generates code | ✅ | ✅ | ✅ |
 | Runs tests autonomously | ❌ | ✅ | ✅ |
-| Opens the PR | ❌ | ✅ | ✅ |
+| Opens the PR for you | ❌ | ✅ | ✅ |
 | **Reviews its own diff before shipping** | ❌ | ❌ | ✅ |
 | **Revises based on its own review** | ❌ | ❌ | ✅ |
-| Ships an audit trail you can defend | ❌ | partial | ✅ |
+| Full audit trail in the PR body | ❌ | partial | ✅ |
+| Cost estimate per run | ❌ | ❌ | ✅ |
 
-The killer feature is the **self-review loop**: a second Claude instance, with a different system prompt and zero context from the engineering pass, audits the diff for bug risk, edge cases, test coverage, and scope creep. If the verdict is `REQUEST_CHANGES`, the engineering agent does a revision pass with the review feedback as input. The full report ships in the PR body — no black box.
+### The self-review loop — the killer feature
 
-## Architecture
+A **second Claude instance**, with a completely fresh context and a different system prompt, audits the diff for:
+
+- 🐛 **Bug risk** — logic errors, off-by-ones, null dereferences
+- 🔲 **Edge cases** — inputs the engineering agent didn't consider
+- 🧪 **Test coverage** — is the change actually tested?
+- 🎯 **Scope creep** — did the agent touch things it shouldn't?
+
+If the verdict is `REQUEST_CHANGES`, the engineering agent does a **revision pass** with the review feedback as input. The full report ships in the PR body — no black box, no guessing what the AI did.
+
+---
+
+## 🚀 Quick start
+
+### Prerequisites
+
+- Node.js 18+
+- An [Anthropic API key](https://console.anthropic.com/)
+- A [GitHub Personal Access Token](https://github.com/settings/tokens) with `repo` scope
+
+### Installation
+
+```bash
+git clone <your-fork-url>
+cd github-agent
+npm install
+```
+
+Create a `.env` file in the repo root:
+
+```ini
+ANTHROPIC_API_KEY=sk-ant-...
+GITHUB_TOKEN=ghp_...
+```
+
+### Usage
+
+```bash
+# Fix an issue and open a PR (the main event)
+node src/pipeline.js issue https://github.com/your/repo/issues/42
+
+# Dry run — full pipeline, no commits/push/PR
+node src/pipeline.js issue https://github.com/your/repo/issues/42 --dry-run
+
+# Audit an existing PR (no editing — just the review report)
+node src/pipeline.js review https://github.com/your/repo/pull/123
+```
+
+Or use the npm shorthand scripts:
+
+```bash
+npm run issue -- https://github.com/your/repo/issues/42
+npm run review -- https://github.com/your/repo/pull/123
+```
+
+---
+
+## 🏗️ Architecture
 
 ```
 ┌─────────────────┐
-│ GitHub issue    │
+│  GitHub Issue   │
 └────────┬────────┘
          │
          ▼
 ┌─────────────────────────────────────────────────────┐
-│ Engineering Agent (Claude Opus + tool use)          │
-│   Tools: read_file, list_files, write_file,         │
-│          apply_patch, run_tests, git_diff,          │
-│          git_status, finish                         │
-│   Loop: explore → patch → test → repeat             │
-└────────┬────────────────────────────────────────────┘
-         │  diff
-         ▼
+│  Engineering Agent  (Claude + tool use)             │
+│                                                     │
+│  Tools:  read_file   list_files   write_file        │
+│          apply_patch  run_tests   git_diff          │
+│          git_status   finish                        │
+│                                                     │
+│  Loop:   explore → patch → test → repeat            │
+└────────────────────┬────────────────────────────────┘
+                     │  diff
+                     ▼
 ┌─────────────────────────────────────────────────────┐
-│ Self-Review (Claude Opus, fresh context)            │
-│   Audits: bug risk, edge cases, test coverage,      │
-│           scope creep                               │
-│   Verdict: APPROVE / REQUEST_CHANGES / DISCUSS      │
-└────────┬────────────────────────────────────────────┘
-         │
-    ┌────┴─────┐
-    │          │ REQUEST_CHANGES
-    │APPROVE   ▼
-    │     ┌────────────────────┐
-    │     │ Revision pass      │
-    │     │ (engineering agent │
-    │     │  with review as    │
-    │     │  feedback)         │
-    │     └────┬───────────────┘
-    │          │
-    ▼          ▼
-┌─────────────────────┐
-│ Commit + push + PR  │  ← PR body includes self-review report
-└─────────────────────┘
+│  Self-Review  (Claude, fresh context)               │
+│                                                     │
+│  Audits:  bug risk · edge cases                     │
+│           test coverage · scope creep               │
+│                                                     │
+│  Verdict:  APPROVE / REQUEST_CHANGES / DISCUSS      │
+└─────────────┬───────────────────────────────────────┘
+              │
+       ┌──────┴────────────────────┐
+       │ APPROVE                   │ REQUEST_CHANGES
+       │                           ▼
+       │               ┌───────────────────────┐
+       │               │  Revision Pass        │
+       │               │  (engineering agent   │
+       │               │   + review feedback)  │
+       │               └──────────┬────────────┘
+       │                          │
+       ▼                          ▼
+┌────────────────────────────────────┐
+│  Commit → Push → Open PR           │
+│  (PR body includes review report)  │
+└────────────────────────────────────┘
 ```
 
-## Quick start
+---
 
-```bash
-git clone <this repo>
-cd github-agent
-npm install
+## 🛡️ Safety guardrails
 
-cp .env.example .env
-# fill in:
-#   ANTHROPIC_API_KEY=sk-ant-...
-#   GITHUB_TOKEN=ghp_...   (needs `repo` scope on the target)
+The agent has real write access to files on disk. We've put real fences around it:
 
-# Try it (dry run — no commits, no PR)
-node src/pipeline.js issue https://github.com/your/repo/issues/42 --dry-run
+| Guardrail | Detail |
+|---|---|
+| **Path traversal blocked** | `read_file`, `write_file`, `apply_patch` reject any path escaping the repo root |
+| **Test command allowlist** | `run_tests` only accepts `npm test`, `pytest`, `go test`, `cargo test`, etc. — no arbitrary shell |
+| **Iteration cap** | Hard stop at 18 agent turns per pass |
+| **Cost kill-switch** | Configurable per-run USD ceiling (default $5.00) — aborts before overspending |
+| **Token leak prevention** | GitHub PAT is used for clone + push but never written to `.git/config` |
+| **Patch uniqueness** | `apply_patch` requires the target string to be unique in the file — no accidental multi-site rewrites |
+| **`--dry-run` mode** | Full pipeline simulation without committing, pushing, or opening anything |
 
-# Actually ship a PR
-node src/pipeline.js issue https://github.com/your/repo/issues/42
+---
 
-# Review an existing PR (no autonomous editing — just the audit)
-node src/pipeline.js review https://github.com/your/repo/pull/123
-```
+## 💰 Cost transparency
 
-## Safety guardrails
+Every run prints a token breakdown and a USD estimate. The audit trail records the same numbers in the PR body.
 
-The agent has real write access to the repo on disk. We've put real fences around it:
-
-- **Path traversal blocked.** `read_file`, `write_file`, `apply_patch` reject any path that escapes the repo root.
-- **Test command allowlist.** `run_tests` only accepts commands prefixed with `npm test`, `pytest`, `go test`, `cargo test`, etc. — no arbitrary shell.
-- **Iteration cap.** The agent has 18 turns max. Beyond that the loop hard-stops.
-- **Token leak prevention.** GitHub PAT is used for clone + push but never persisted to `.git/config` (we strip the remote URL after clone).
-- **Apply-patch uniqueness.** `apply_patch` requires the target string to be unique in the file — no accidental multi-site rewrites.
-- **`--dry-run` mode.** Run end-to-end without committing/pushing/opening anything.
-
-## Cost transparency
-
-Every run prints token usage and a USD estimate. The audit trail records the same numbers. Typical issue: $0.20 – $1.50 depending on repo size and how many revision passes the self-review triggers.
-
-## Project structure
+**Typical cost per issue:** $0.20 – $1.50, depending on repo size and whether the self-review triggers a revision pass.
 
 ```
-src/
-  pipeline.js              ← CLI entry
-  orchestrator.js          ← engineering → self-review → revision → PR
-  config.js                ← model, limits, costs
-  agents/
-    engineeringAgent.js    ← issue → autonomous fix
-    reviewCopilot.js       ← diff → structured audit
-    agentLoop.js           ← multi-turn tool-use loop with telemetry
-    tools.js               ← tool schemas + sandboxed handlers
-  prompts/
-    engineering.js         ← agentic system prompt + revision prompt
-    review.js              ← review system prompt + verdict format
-  mapper/
-    repoMap.js             ← walk + read source files
-    contextSelector.js     ← (legacy) Claude-picked relevant files
-  utils/
-    githubUrl.js           ← parse owner/repo/number from GitHub URLs
-  cli/
-    output.js              ← pretty terminal + cost summary
-tests/
-  tools.test.js            ← path traversal, allowlist, apply_patch uniqueness
-  repoMap.test.js
-  githubUrl.test.js
-  stripFences.test.js
+Token usage (engineering + revision)
+  input:      12,403 tok   @  $3.00 / MTok
+  output:      1,847 tok   @ $15.00 / MTok
+  cache read:  8,912 tok   @  $0.30 / MTok
+  ─────────────────────────────────────
+  estimated cost:  $0.0676
 ```
 
-## Tests
+> Rates are read from `src/config.js` (`COST_INPUT_PER_MTOK`, `COST_OUTPUT_PER_MTOK`, `COST_CACHE_READ_PER_MTOK`). Update them there if Anthropic's pricing changes.
+
+---
+
+## 📁 Project structure
+
+```
+github-agent/
+├── src/
+│   ├── pipeline.js          ← CLI entry point
+│   ├── orchestrator.js      ← engineering → self-review → revision → PR
+│   ├── config.js            ← model, limits, cost rates
+│   ├── agents/
+│   │   ├── engineeringAgent.js  ← issue → autonomous fix
+│   │   ├── reviewCopilot.js     ← diff → structured audit
+│   │   ├── agentLoop.js         ← multi-turn tool-use loop + telemetry
+│   │   └── tools.js             ← tool schemas + sandboxed handlers
+│   ├── prompts/
+│   │   ├── engineering.js       ← agentic system prompt + revision prompt
+│   │   └── review.js            ← review system prompt + verdict format
+│   ├── mapper/
+│   │   ├── repoMap.js           ← walk + read source files
+│   │   └── contextSelector.js   ← (legacy) Claude-picked relevant files
+│   ├── utils/
+│   │   └── githubUrl.js         ← parse owner/repo/number from GitHub URLs
+│   └── cli/
+│       └── output.js            ← pretty terminal output + cost summary
+└── tests/
+    ├── tools.test.js            ← path traversal, allowlist, apply_patch uniqueness
+    ├── repoMap.test.js
+    ├── githubUrl.test.js
+    └── stripFences.test.js
+```
+
+---
+
+## 🧪 Tests
 
 ```bash
 npm test
 ```
 
-## Roadmap
+The test suite covers the security-critical paths: path traversal prevention, the test-command allowlist, `apply_patch` uniqueness enforcement, repo mapping, and GitHub URL parsing.
 
-- Web dashboard streaming the live agent feed (great for ops + demos)
-- Fork-and-PR mode for repos where you don't have write access
-- Multi-issue batch mode (`triage` subcommand)
-- LangSmith / Helicone telemetry export
-- Pluggable language adapters (rustfmt + cargo, gofmt + go vet, ruff + pytest)
+---
 
-## License
+## 🗺️ Roadmap
 
-MIT
+- [ ] **Web dashboard** — streaming live agent feed (great for ops + demos)
+- [ ] **Fork-and-PR mode** — for repos where you don't have write access
+- [ ] **Batch mode** — process multiple issues in one run (`triage` subcommand)
+- [ ] **Telemetry export** — LangSmith / Helicone integration
+- [ ] **Language adapters** — `rustfmt` + `cargo`, `gofmt` + `go vet`, `ruff` + `pytest`
+
+---
+
+## 📄 License
+
+[MIT](LICENSE) — use it, fork it, ship it.

--- a/src/config.js
+++ b/src/config.js
@@ -11,9 +11,10 @@ module.exports = {
   TOOL_OUTPUT_TRUNCATE: 8000,
 
   // Cost per 1M tokens (USD) — for the audit trail summary line
-  COST_INPUT_PER_MTOK: 15.0,
-  COST_OUTPUT_PER_MTOK: 75.0,
-  COST_CACHE_READ_PER_MTOK: 1.5,
+  // Claude 3.5 Sonnet pricing; update here if rates change
+  COST_INPUT_PER_MTOK: 3.0,
+  COST_OUTPUT_PER_MTOK: 15.0,
+  COST_CACHE_READ_PER_MTOK: 0.30,
 
   // Hard kill switch — abort an agent loop if its cost crosses this many USD.
   // Override per-run with --max-cost=X.XX


### PR DESCRIPTION
Resolves #1

## What changed

This revision pass addresses all four actionable concerns raised by the reviewer:

1. **Removed the static "tests-passing" badge** — The hardcoded `https://img.shields.io/badge/tests-passing-brightgreen` badge was removed entirely. No CI workflow file exists in this repo, so there is no live badge source to link to. The remaining three badges (model, license, Node version) are all factual and static by nature.

2. **Fixed token cost rates in `src/config.js` and the README example** — The previous rates (`$15.00/$75.00/$1.50` per MTok) matched Claude 3 Opus pricing, not Claude 3.5 Sonnet. They have been corrected to Sonnet pricing (`$3.00/$15.00/$0.30` per MTok) in `src/config.js` (the single source of truth used by `src/utils/cost.js` for all runtime calculations), and the README sample output now shows matching rates and a recomputed estimated cost (`$0.0676`). A note is added pointing readers to `src/config.js` to update rates if pricing changes.

3. **Fixed the `git clone` placeholder URL** — Changed `https://github.com/your/github-agent.git` (a 404-producing fake URL) to `<your-fork-url>`, which is clearly a placeholder. The original README used `<this repo>` for the same reason.

4. **Fixed the `.env.example` reference** — `cp .env.example .env` was removed since no `.env.example` file exists in the repo. The step now simply says "Create a `.env` file in the repo root:" followed by the required keys.

Two reviewer concerns were **not** changed because they turned out to be accurate after source verification: (a) the "Cost kill-switch" safety guardrail row — `config.js` does have `DEFAULT_MAX_USD_PER_RUN: 5.0` with an explicit "Hard kill switch" comment, so the claim is substantiated; (b) the `npm run issue` / `npm run review` shortcuts — `package.json` already contains both scripts.

All 33 tests pass.

## Automated self-review

<details><summary>Click to expand</summary>

## 1. Bug Risk

**Static "tests-passing" badge (README.md, line ~20)**

```markdown
<img src="https://img.shields.io/badge/tests-passing-brightgreen?style=flat-square" alt="Tests Passing">
```

This is a hardcoded static badge, not a live CI badge (e.g., from GitHub Actions). It will display "passing" regardless of actual test state, including if future commits break the suite. This is actively misleading to potential users and contributors. A real badge would link to a CI workflow artifact (e.g., `https://github.com/<owner>/<repo>/actions/workflows/<workflow>.yml/badge.svg`).

**Hardcoded "Cost kill-switch" in safety table (README.md, Safety section)**

> **Cost kill-switch** | Configurable per-run USD ceiling (default $5.00) — aborts before overspending

This guardrail row is *new* — it does not appear in the original README. The PR body states "no source code was changed." If this feature does not actually exist in `config.js` or `orchestrator.js`, this is a false advertised safety guarantee, which is a meaningful trust issue for a tool with real write access to repos.

**Annotated token breakdown snippet (README.md, Cost section)**

```
  input:      12,403 tok   @ $15.00 / MTok
  output:      1,847 tok   @ $75.00 / MTok
  cache read:  8,912 tok   @  $1.50 / MTok
```

These rates match Claude 3 Opus pricing, not Claude 3.5 Sonnet (Sonnet input is ~$3.00/MTok, output ~$15.00/MTok at time of writing). The PR explicitly corrects "Claude Opus" → "Claude Sonnet" in the prose, but the cost table still uses Opus-tier prices. This contradicts the correction and will confuse users estimating their own costs.

**`npm run issue` / `npm run review` shortcuts (README.md, Usage section)**

```bash
npm run issue -- https://github.com/your/repo/issues/42
npm run review -- https://github.com/your/repo/pull/123
```

No evidence is provided that these scripts exist in `package.json`. If they don't, copy-pasting from the Quick Start will produce `npm ERR! Missing script: "issue"`.

---

## 2. Edge Cases

**Anchor link correctness** — The nav bar links like `#-quick-start` and `#️-architecture` use emoji in the heading. GitHub's anchor generation strips most special characters but handles emoji inconsistently across renderer versions. `#️-architecture` (with a variation selector `️` in the emoji) may not resolve correctly on all GitHub markdown renderers. Should be verified by actually clicking the links on GitHub.

**`git clone` URL in Quick Start** — The installation block now reads:
```bash
git clone https://github.com/your/github-agent.git
```
This is a placeholder URL. The original used `<this repo>` which was at least honest about being a placeholder. A user who copies this will get a 404. This should either be the real URL or clearly marked as `<your-fork-url>`.

**`.env.example` assumed to exist** — The Quick Start says `cp .env.example .env` but neither the original nor the diff confirms this file exists in the repo. If it doesn't, the step silently fails.

---

## 3. Test Coverage

This is a documentation-only PR. There are no code behavior changes, so no new test coverage is required for correctness. However:

- The static "tests-passing" badge creates an implicit ongoing claim that is untested/unautomated. The project should have a real CI badge backed by a workflow file if it wants to make this claim durably.
- The new "Cost kill-switch" guardrail row, if it represents real functionality, is a security/safety-critical path that should already have test coverage. Its sudden appearance in docs without a corresponding test or source reference is a red flag.

---

## 4. Scope Creep

The stated scope is documentation polish. All changes are confined to `README.md`, which is appropriate. However, two items represent *functional claims* introduced without corresponding code:

1. **"Cost kill-switch"** guardrail — new claim with no cited source implementation.
2. **`npm run issue` / `npm run review`** scripts — new usage instructions with no `package.json` change.

These are not out-of-scope edits to other files, but they do introduce verifiable claims about the codebase that the PR cannot substantiate without showing the relevant `package.json` and `config.js` lines.

---

## 5. Verdict

**REQUEST_CHANGES**

The PR is well-intentioned and meaningfully improves the README's scannability and structure. However, it introduces at least three materially false or unverified claims: a hardcoded "tests-passing" badge that will lie when tests break; a new "Cost kill-switch" safety guardrail that appears nowhere in the stated "no source code changed" diff and may not exist; and token cost rates in the example snippet that contradict the Opus→Sonnet correction made elsewhere in the same PR. Any one of these would be acceptable as a nit in isolation, but together they undermine trust in a tool whose primary selling point is that it "ships code autonomously" — the README needs to be as rigorous as the code it describes. Fix the badge to use a live CI source, verify or remove the cost kill-switch row, and align the token rate example with Sonnet pricing before merging.

</details>

---
🤖 Generated by [github-agent](https://github.com/) — autonomous engineering + self-review with Claude.